### PR TITLE
Fix entry refresh

### DIFF
--- a/feedler/feedparser.py
+++ b/feedler/feedparser.py
@@ -39,6 +39,8 @@ def parse(obj, raw, stream):
     # Collect text in nested JSON content
     if 'content' in obj.raw:
         obj.content = obj.raw['content']
+    elif 'fullContent' in obj.raw:
+        obj.content = obj.raw['fullContent']
     else:
         if 'summary' in obj.raw:
             if 'content' in obj.raw['summary']:

--- a/feedler/refresh.py
+++ b/feedler/refresh.py
@@ -67,10 +67,9 @@ def refresh_stream(stream, settings, retry=False):
     for raw_entry in contents['items']:
         eid = raw_entry['id']
         # Create or update data
-        try:
-            entry = Entry.objects.get(entry_id=eid)
+        if Entry.objects.filter(entry_id=eid).exists():
             logger.info("Skipping entry '%s'" % eid)
-        except Entry.DoesNotExist:
+        else:
             logger.info("Adding entry '%s'" % eid)
             entry = Entry()
             # Parse the Feedly object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-# Updated: 23.10.2017
+# Updated: 17.11.2017
 
 # Core
 wagtail==1.13
-Django==1.11.6
+Django==1.11.7
 
 # Database
-psycopg2==2.7.3.1
+psycopg2==2.7.3.2
 dj-database-url==0.4.2
 
 # Content
@@ -20,7 +20,7 @@ django-redis==4.8.0
 
 # Frontend
 django-libsass==0.7
-libsass==0.13.3
+libsass==0.13.4
 Pillow==4.3.0
 
 # Development tools
@@ -30,4 +30,4 @@ stellar==0.4.3
 gunicorn==19.7.1
 whitenoise==3.3.1
 ConcurrentLogHandler==0.9.1
-django-anymail==1.0
+django-anymail==1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Updated: 17.11.2017
 
 # Core
-wagtail==1.13
+wagtail==1.13.1
 Django==1.11.7
 
 # Database


### PR DESCRIPTION
Some Feedly entries use a different field than specified for the HTML content of an entry. A minor improvement was made to error handling in refreshes. Additionally, several upstream packages were updated.