### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ wagtail==2.12.5
 elasticsearch>=5.0.0,<6.0.0
 
 # Database
-psycopg2-binary==2.9.1
+psycopg2-binary==2.8.6
 dj-database-url==0.5.0
 
 # Content


### PR DESCRIPTION
Downgrade psycopg2-binary to 2.8.6, because of the issue

```
django.core.serializers.base.DeserializationError: Problem installing fixture '/home/app/publichealth.home.json': database connection isn't set to UTC: (wagtailcore.pagerevision:pk=1) field_value was '['oleg']'
```

More info: https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147