### PR TITLE
Enable legacy rich-text wrapper

### DIFF
--- a/publichealth/settings/base.py
+++ b/publichealth/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.forms',
     'wagtail.contrib.redirects',
     'wagtail.contrib.search_promotions',
+    "wagtail.contrib.legacy.richtext",
 
     'wagtail.embeds',
     'wagtail.sites',


### PR DESCRIPTION
In wagtail version prior to 2.10, the rich text values were
enclosed in a `<div class="rich-text">` element. This behavior was
removed since 2.10.

This pull request re-enables this.

See: https://docs.wagtail.io/en/stable/releases/2.10.html#div-class-rich-text-wrappers-removed-from-rich-text